### PR TITLE
[Resolve] @Setter를 삭제하고 정적 팩토리 메소드로 데이터를 세팅

### DIFF
--- a/chan/src/main/java/k5s/reviewdevelop/InitDb.java
+++ b/chan/src/main/java/k5s/reviewdevelop/InitDb.java
@@ -2,6 +2,7 @@ package k5s.reviewdevelop;
 
 import k5s.reviewdevelop.domain.Member;
 import k5s.reviewdevelop.domain.Movie;
+import k5s.reviewdevelop.service.MovieService;
 import k5s.reviewdevelop.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -22,36 +23,33 @@ public class InitDb {
         initService.dbInit1();
         initService.dbInit2();
     }
+
     @Component
     @Transactional
-
     @RequiredArgsConstructor
     static class InitService {
         private final EntityManager em;
         private final ReviewService reviewService;
+        private final MovieService movieService;
 
         public void dbInit1() {
             Member member = createMember("emrhssla@naver.com");
             em.persist(member);
-            Movie movie1 = createMovie("Inception", "Its movie A");
-            em.persist(movie1);
-            Movie movie2 = createMovie("Venom", "Its movie B");
-            em.persist(movie2);
-            reviewService.register(member.getId(), movie1.getId(), "재미있습니다", 8);
-            reviewService.register(member.getId(), movie2.getId(), "재미없습니다", 3);
-            reviewService.register(member.getId(), movie2.getId(), "완전 재미있습니다", 9);
+            Long movie1 = movieService.register("Inception", "Its movie A");
+            Long movie2 = movieService.register("Venom", "Its movie B");
+            reviewService.register(member.getId(), movie1, "재미있습니다", 8);
+            reviewService.register(member.getId(), movie2, "재미없습니다", 3);
+            reviewService.register(member.getId(), movie2, "완전 재미있습니다", 9);
         }
 
         public void dbInit2() {
 
             Member member = createMember("emrhssla@gmail.com");
             em.persist(member);
-            Movie movie1 = createMovie("Avatar", "Its movie C");
-            em.persist(movie1);
-            Movie movie2 = createMovie("IronMan", "Its movie D");
-            em.persist(movie2);
-            reviewService.register(member.getId(), movie1.getId(), "그저그래요",6);
-            reviewService.register(member.getId(), movie2.getId(), "재미없습니다",4);
+            Long movie1 = movieService.register("Avatar", "Its movie C");
+            Long movie2 = movieService.register("IronMan", "Its movie D");
+            reviewService.register(member.getId(), movie1, "그저그래요",6);
+            reviewService.register(member.getId(), movie2, "재미없습니다",4);
 
         }
 
@@ -63,13 +61,6 @@ public class InitDb {
             return member;
         }
 
-        private Movie createMovie(String name, String description){
-            Movie movie = new Movie();
-            movie.setName(name);
-            movie.setDescription(description);
-            em.persist(movie);
-            return movie;
-        }
 
     }
 }

--- a/chan/src/main/java/k5s/reviewdevelop/domain/Movie.java
+++ b/chan/src/main/java/k5s/reviewdevelop/domain/Movie.java
@@ -6,12 +6,13 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Movie {
 
     @Id
@@ -40,11 +41,20 @@ public class Movie {
         members.add(member);
     }
 
-    public void setAverageScore(int score){
+    public void createAverageScore(int score){
         this.sumScore += score;
         this.num += 1;
         this.averageScore = (sumScore/num);
     }
+
+    //== 생성 메서드 ==//
+    public static Movie createMovie(String name, String description){
+        Movie movie = new Movie();
+        movie.name = name;
+        movie.description = description;
+        return movie;
+    }
+
 
     //==비지니스 로직==//
     /** 리뷰 삭제 */

--- a/chan/src/main/java/k5s/reviewdevelop/domain/Review.java
+++ b/chan/src/main/java/k5s/reviewdevelop/domain/Review.java
@@ -11,7 +11,6 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Review {
 
@@ -21,7 +20,7 @@ public class Review {
     @Column(name = "review_id")
     private Long id;
 
-    private Integer score;
+    private int score;
 
     private LocalDateTime dateTime;
 
@@ -37,14 +36,14 @@ public class Review {
     @JoinColumn(name = "movie_id")
     private Movie movie;
 
-    public void setMember(Member member) {
+    public void mappingMember(Member member) {
         this.member = member;
         member.getReviews().add(this);
     }
 
-    public void setMovie(Movie movie, int score) {
+    public void mappingMovie(Movie movie, int score) {
         this.score = score;
-        movie.setAverageScore(score);
+        movie.createAverageScore(score);
         this.movie = movie;
         movie.getReviews().add(this);
     }
@@ -52,10 +51,10 @@ public class Review {
     //==생성 메서드==//
     public static Review createReview(Member member, Movie movie, String description, int score) {
         Review review = new Review();
-        review.setMember(member);
-        review.setMovie(movie, score);
-        review.setDescription(description);
-        review.setDateTime(LocalDateTime.now());
+        review.mappingMember(member);
+        review.mappingMovie(movie, score);
+        review.description = description;
+        review.dateTime =  LocalDateTime.now();
         return review;
     }
 

--- a/chan/src/main/java/k5s/reviewdevelop/repository/MovieRepository.java
+++ b/chan/src/main/java/k5s/reviewdevelop/repository/MovieRepository.java
@@ -32,10 +32,8 @@ public class MovieRepository {
         try{
             movieTypedQuery.getSingleResult();
         } catch(NoResultException e){
-            Movie movie = new Movie();
-            movie.setName("NoMovie");
-            movie.setDescription("NoMovie");
-            em.persist(movie);
+            Movie movie = Movie.createMovie("NoMovie", "NoMovie");
+            this.save(movie);
             return movie;
         }
         return movieTypedQuery.getSingleResult();

--- a/chan/src/main/java/k5s/reviewdevelop/service/MovieService.java
+++ b/chan/src/main/java/k5s/reviewdevelop/service/MovieService.java
@@ -32,4 +32,14 @@ public class MovieService {
     public Movie findReviews(Long movieId) {
         return movieRepository.findReviews(movieId);
     }
+
+    public Long register(String name, String description){
+
+        Movie movie = Movie.createMovie(name, description);
+        movieRepository.save(movie);
+
+        return movie.getId();
+
+    }
+
 }

--- a/chan/src/test/java/k5s/reviewdevelop/service/ReviewServiceTest.java
+++ b/chan/src/test/java/k5s/reviewdevelop/service/ReviewServiceTest.java
@@ -3,6 +3,7 @@ package k5s.reviewdevelop.service;
 import k5s.reviewdevelop.domain.Member;
 import k5s.reviewdevelop.domain.Movie;
 import k5s.reviewdevelop.domain.Review;
+import k5s.reviewdevelop.repository.MovieRepository;
 import k5s.reviewdevelop.repository.ReviewRepository;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,20 +34,27 @@ public class ReviewServiceTest {
     @Autowired
     ReviewRepository reviewRepository;
 
+    @Autowired
+    MovieService movieService;
+
+    @Autowired
+    MovieRepository movieRepository;
+
 
     @Test
     public void 한개리뷰등록() throws Exception{
 
         //Given
         Member member = createMember("emrhssla@naver.com", LocalDate.of(2019,11,12));
-        Movie movie = createMovie("Inception", "Its a very Hot Movie. So, I recommended this Movie to you");
+        Long movieId = movieService.register("Inception", "Its a very Hot Movie. So, I recommended this Movie to you");
         int score = 2;
 
         //When
-        Long reviewId = reviewService.register(member.getId(), movie.getId(), "재미없다", score);
+        Long reviewId = reviewService.register(member.getId(), movieId, "재미없다", score);
 
 
         //Then
+        Movie movie = movieRepository.findOne(movieId);
         Review getReview = reviewRepository.findOne(reviewId);
         assertEquals("멤버의 리뷰 점수는 2점과 같다", 2, getReview.getScore());
         assertEquals("리뷰는 한개여야한다.",1, movie.getReviews().size());
@@ -60,18 +68,19 @@ public class ReviewServiceTest {
 
         //Given
         Member member = createMember("emrhssla@naver.com", LocalDate.of(2019,11,12));
-        Movie movie = createMovie("Inception", "Its a very Hot Movie. So, I recommended this Movie to you");
+        Long movieId = movieService.register("Inception", "Its a very Hot Movie. So, I recommended this Movie to you");
         Member member2 = createMember("emrhssla@gmail.com", LocalDate.of(2019,11,12));
         int score = 2;
         int score2 = 9;
 
         //When
-        Long reviewId = reviewService.register(member.getId(), movie.getId(), "이게 영화냐",score);
-        Long reviewId2 = reviewService.register(member2.getId(), movie.getId(), "너무 재밌다",score2);
+        Long reviewId = reviewService.register(member.getId(), movieId, "이게 영화냐",score);
+        Long reviewId2 = reviewService.register(member2.getId(), movieId, "너무 재밌다",score2);
 
         //Then
         Review getReview = reviewRepository.findOne(reviewId);
         Review getReview2 = reviewRepository.findOne(reviewId2);
+        Movie movie = movieRepository.findOne(movieId);
         assertEquals("멤버2의 리뷰 점수는 9점과 같다", 9, getReview2.getScore());
         assertEquals("리뷰가 늘어나야한다.",2, movie.getReviews().size());
         assertEquals("리뷰의 점수 종합은 각 멤버 점수의 합이어야한다.",2 + 9, movie.getSumScore(),0.0001);
@@ -83,17 +92,18 @@ public class ReviewServiceTest {
     public void 리뷰삭제() {
         //Given
         Member member = createMember("emrhssla@naver.com", LocalDate.of(2019,11,12));
-        Movie movie = createMovie("Inception", "Its a very Hot Movie. So, I recommended this Movie to you");
+        Long movieId = movieService.register("Inception", "Its a very Hot Movie. So, I recommended this Movie to you");
         int score = 8;
         int score2 = 4;
-        Long reviewId = reviewService.register(member.getId(), movie.getId(), "아주 재밌어요",score);
-        Long reviewId2 = reviewService.register(member.getId(), movie.getId(), "재미 없다",score2);
+        Long reviewId = reviewService.register(member.getId(), movieId, "아주 재밌어요",score);
+        Long reviewId2 = reviewService.register(member.getId(), movieId, "재미 없다",score2);
 
         //When
         reviewService.deleteReview(reviewId2);
 
         //Then
         Review getReview = reviewRepository.findOne(reviewId);
+        Movie movie = movieRepository.findOne(movieId);
         assertEquals("영화에 등록된 리뷰의 갯수는 줄어야한다",2-1, movie.getNum());
         assertEquals("리뷰의 점수 종합은 삭제된 리뷰의 점수가 빠져야한다",12-4, movie.getSumScore(),0.0001);
         assertEquals("리뷰의 평균 점수는 총점/갯수이다",8/1, movie.getAverageScore(),0.0001);
@@ -112,12 +122,5 @@ public class ReviewServiceTest {
         return member;
     }
 
-    private Movie createMovie(String name, String description){
-        Movie movie = new Movie();
-        movie.setName(name);
-        movie.setDescription(description);
-        em.persist(movie);
-        return movie;
-    }
 
 }


### PR DESCRIPTION
## Issue
- close #34 

## 목적
`@Setter`를 삭제한다

- `setter`를 외부에 노출하는 것을 줄여야한다
- 생성 이후에 변경할 필요가 없는데, `setter`가 외부에 노출되어 있으면 이것을 사용하는 다른 개발자들은 이 setter를 호출해야 하나? 말아야 하나 고민하게된다. 그런데 `setter`나 변경 가능한 메서드가 없으면, 아 이건 내가 막 변경하면 안되는구나 라고 리마인드되게 한다

## Task
  - `@Setter`를 삭제하고 **정적 팩토리 메소드**를 이용하여 데이터를 세팅한다 
  - `member`는 `setter`를 유지한다


