### PR TITLE
[FIX] 리뷰 없는 영화 조회 버그

### DIFF
--- a/chan/src/main/java/k5s/reviewdevelop/controller/ReviewController.java
+++ b/chan/src/main/java/k5s/reviewdevelop/controller/ReviewController.java
@@ -6,6 +6,7 @@ import k5s.reviewdevelop.domain.Movie;
 import k5s.reviewdevelop.domain.Review;
 import k5s.reviewdevelop.form.ReviewForm;
 import k5s.reviewdevelop.repository.ReviewRepository;
+import k5s.reviewdevelop.service.MemberService;
 import k5s.reviewdevelop.service.MovieService;
 import k5s.reviewdevelop.service.ReviewService;
 import lombok.RequiredArgsConstructor;
@@ -28,13 +29,18 @@ public class ReviewController {
 
     private final ReviewService reviewService;
     private final MovieService movieService;
+    private final MemberService memberService;
 
     @GetMapping
-    public String list(@PathVariable("movieId") Long movieId,Model model) {
+    public String list(@SessionAttribute(name = "loginMemberTEST", required = false) Member member, @PathVariable("movieId") Long movieId,Model model) {
 
         Movie movie = movieService.findReviews(movieId);
         if (movie.getName() == "NoMovie"){
             return "movies/reviews/error";
+        }
+        log.info(String.valueOf(member));
+        if (member != null) {
+            model.addAttribute("memberId", member.getId());
         }
         model.addAttribute("movieName", movie.getName());
         model.addAttribute("movieId", movie.getId());
@@ -69,6 +75,15 @@ public class ReviewController {
             return "redirect:/loginPage";
         }
         reviewService.register(loginMember.getId(), movieId, form.getDescription(), form.getScore());
+        return "redirect:/movies/{movieId}/reviews";
+    }
+
+    @PostMapping(value = "/{reviewId}/cancel")
+    public String cancelOrder(@PathVariable("movieId") Long movieId, @PathVariable("reviewId") Long reviewId) {
+        Movie movie = movieService.findOne(movieId);
+        log.info("총 영화점수" + String.valueOf(movie.getSumScore()));
+        reviewService.deleteReview(reviewId);
+        log.info("총 영화점수" + String.valueOf(movie.getSumScore()));
         return "redirect:/movies/{movieId}/reviews";
     }
 }

--- a/chan/src/main/java/k5s/reviewdevelop/domain/Review.java
+++ b/chan/src/main/java/k5s/reviewdevelop/domain/Review.java
@@ -59,8 +59,8 @@ public class Review {
     }
 
     //==비지니스 로직==//
-    /** 리뷰 삭제 */
-    public void delete() {
+    /** 리뷰 점수 삭제 */
+    public void deleteScore() {
         movie.deleteReview(score);
     }
 

--- a/chan/src/main/java/k5s/reviewdevelop/repository/MovieRepository.java
+++ b/chan/src/main/java/k5s/reviewdevelop/repository/MovieRepository.java
@@ -28,7 +28,7 @@ public class MovieRepository {
         return em.createQuery("select m from Movie m", Movie.class).getResultList();
     }
     public Movie findReviews(Long id){
-        TypedQuery<Movie> movieTypedQuery = em.createQuery("select distinct m from Movie m join fetch m.reviews where m.id = :movieId", Movie.class).setParameter("movieId", id);
+        TypedQuery<Movie> movieTypedQuery = em.createQuery("select distinct m from Movie m left join fetch m.reviews where m.id = :movieId", Movie.class).setParameter("movieId", id);
         try{
             movieTypedQuery.getSingleResult();
         } catch(NoResultException e){

--- a/chan/src/main/java/k5s/reviewdevelop/repository/ReviewRepository.java
+++ b/chan/src/main/java/k5s/reviewdevelop/repository/ReviewRepository.java
@@ -1,10 +1,16 @@
 package k5s.reviewdevelop.repository;
 
+import k5s.reviewdevelop.domain.Member;
 import k5s.reviewdevelop.domain.Review;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -17,5 +23,15 @@ public class ReviewRepository {
     public Review findOne(Long id) {
         return em.find(Review.class, id);
     }
+
+    //리뷰 삭제
+    @Transactional
+    public int delete(Long id) {
+        String jpql = "delete from Review r where r.id = :id";
+        Query query = em.createQuery(jpql).setParameter("id",id);
+        int rows =query.executeUpdate();
+        return rows;
+    }
+
 
 }

--- a/chan/src/main/java/k5s/reviewdevelop/service/ReviewService.java
+++ b/chan/src/main/java/k5s/reviewdevelop/service/ReviewService.java
@@ -44,7 +44,8 @@ public class ReviewService {
         //리뷰 엔티티 조회
         Review review = reviewRepository.findOne(reviewId);
         //리뷰 삭제
-        review.delete();
+        review.deleteScore();
+        reviewRepository.delete(reviewId);
     }
 
 }

--- a/chan/src/main/resources/templates/movies/reviews/reviewList.html
+++ b/chan/src/main/resources/templates/movies/reviews/reviewList.html
@@ -22,7 +22,9 @@
                 <td th:text="${review.description}"></td>
                 <td th:text="${review.dateTime}"></td>
                 <td>
-                    <!--<a href="#" th:href="@{/items/{id}/edit (id=${item.id})}" class="btn btn-primary" role="button">수정</a>-->
+                    <a th:if="${memberId} == ${review.member.id}" href="#"
+                       th:href="'javascript:cancel('+${movieId}+', '+${review.id}+')'"
+                       class="btn btn-danger">삭제</a>
                 </td>
             </tr>
             </tbody>
@@ -31,4 +33,13 @@
     <div th:replace="fragments/footer :: footer"/>
 </div> <!-- /container -->
 </body>
+<script>
+    function cancel(movieId, reviewId) {
+        var form = document.createElement("form");
+        form.setAttribute("method", "post");
+        form.setAttribute("action", "/movies/" + movieId + "/reviews/" + reviewId + "/cancel");
+        document.body.appendChild(form);
+        form.submit();
+    }
+</script>
 </html>

--- a/chan/src/test/java/k5s/reviewdevelop/service/ReviewServiceTest.java
+++ b/chan/src/test/java/k5s/reviewdevelop/service/ReviewServiceTest.java
@@ -97,7 +97,7 @@ public class ReviewServiceTest {
     }
 
     @Test
-    public void 리뷰삭제() {
+    public void 리뷰점수삭제() {
         //Given
         Member member = createMember("emrhssla@naver.com", LocalDate.of(2019,11,12));
         Long movieId = movieService.register("Inception", "Its a very Hot Movie. So, I recommended this Movie to you");
@@ -120,6 +120,45 @@ public class ReviewServiceTest {
         assertEquals("영화에 등록된 리뷰의 갯수는 줄어야한다",1-1, movie.getNum());
         assertEquals("리뷰의 점수 종합은 삭제된 리뷰의 점수가 빠져야한다",8-8, movie.getSumScore(),0.0001);
         assertEquals("리뷰 갯수가 0개일 경우 평균 점수는 0이어야한다",0, movie.getAverageScore(),0.0001);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void 리뷰삭제() throws Exception{
+        //Given
+        Member member = createMember("emrhssla@naver.com", LocalDate.of(2019,11,12));
+        Long movieId = movieService.register("Inception", "Its a very Hot Movie. So, I recommended this Movie to you");
+        int score = 8;
+        int score2 = 4;
+        Long reviewId = reviewService.register(member.getId(), movieId, "아주 재밌어요",score);
+        Long reviewId2 = reviewService.register(member.getId(), movieId, "재미 없다",score2);
+
+        //When
+        reviewService.deleteReview(reviewId2);
+        em.clear(); //영속성컨텍스트를 비운다
+
+        //Then
+        String description = reviewRepository.findOne(reviewId2).getDescription();
+        fail("삭제한 리뷰를 조회할시 NULL 값이어야한다");
+    }
+
+    @Test
+    public void 리뷰삭제후_영화상태() throws Exception{
+        //Given
+        Member member = createMember("emrhssla@naver.com", LocalDate.of(2019,11,12));
+        Long movieId = movieService.register("Inception", "Its a very Hot Movie. So, I recommended this Movie to you");
+        int score = 8;
+        int score2 = 4;
+        Long reviewId = reviewService.register(member.getId(), movieId, "아주 재밌어요",score);
+        Long reviewId2 = reviewService.register(member.getId(), movieId, "재미 없다",score2);
+
+        //When
+        reviewService.deleteReview(reviewId2);
+        em.clear(); //영속성컨텍스트를 비운다
+
+        //Then
+        Movie movie = movieService.findOne(movieId);
+        assertEquals("리뷰 삭제후 해당 영화가 갖는 리뷰의 갯수는 줄어야한다", 2-1, movie.getReviews().size());
+        assertEquals("리뷰의 종합 점수는 줄어야한다", 12-4, movie.getSumScore(), 0.0001);
     }
 
     private Member createMember(String email, LocalDate localDate) {

--- a/chan/src/test/java/k5s/reviewdevelop/service/ReviewServiceTest.java
+++ b/chan/src/test/java/k5s/reviewdevelop/service/ReviewServiceTest.java
@@ -17,6 +17,8 @@ import javax.persistence.PersistenceContext;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 import static org.junit.Assert.*;
 
@@ -40,6 +42,12 @@ public class ReviewServiceTest {
     @Autowired
     MovieRepository movieRepository;
 
+    @Test
+    public void 리뷰없는영화(){
+        Long movieId = movieService.register("Inception", "Its a very Hot Movie. So, I recommended this Movie to you");
+        String name = movieService.findReviews(movieId).getName();
+        assertEquals("영화의 리뷰가 없어도 영화 fetch join 조회는 가능해야한다", "Inception", name);
+    }
 
     @Test
     public void 한개리뷰등록() throws Exception{


### PR DESCRIPTION
## 목적

- 리뷰가 없는 영화를 들어가면 영화를 찾을 수 없다는 페이지가 나타난다
- 실제로 리뷰없는영화를 SQL로 직접조회해도 나타나지않는 문제 발생

## 해결
- 리뷰가 null 값이어도 조회가 되길 위해 `fetch join`에서 `left join fetch`로 수정
- SQL로 보면 `outer join`으로 바꿈

## 관련 issue
- [x] close #36 


## 테스트 사항
```java
@Test
public void 리뷰없는영화(){
    Long movieId = movieService.register("Inception", "Its a very Hot Movie. So, I recommended this Movie to you");
    String name = movieService.findReviews(movieId).getName();
    assertEquals("영화의 리뷰가 없어도 영화 fetch join 조회는 가능해야한다", "Inception", name);
}
```

## Screenshot
<img width="738" alt="image" src="https://user-images.githubusercontent.com/46098949/163082743-800be814-bb6d-4f4d-b41e-1b5081cd1ae1.png">


