### PR TITLE
[Test] 인증서버와 API 통신 테스트

### DIFF
--- a/chan/src/main/java/k5s/reviewdevelop/config/WebClientConfig.java
+++ b/chan/src/main/java/k5s/reviewdevelop/config/WebClientConfig.java
@@ -1,0 +1,18 @@
+package k5s.reviewdevelop.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Value("${msa.auth}")
+    String authServerUrl;
+
+    @Bean
+    public WebClient webClient(){
+        return WebClient.builder().baseUrl(authServerUrl).build();
+    }
+}

--- a/chan/src/main/java/k5s/reviewdevelop/controller/ReviewController.java
+++ b/chan/src/main/java/k5s/reviewdevelop/controller/ReviewController.java
@@ -4,7 +4,7 @@ package k5s.reviewdevelop.controller;
 import k5s.reviewdevelop.domain.Member;
 import k5s.reviewdevelop.domain.Movie;
 import k5s.reviewdevelop.domain.Review;
-import k5s.reviewdevelop.domain.UpdateReviewDto;
+import k5s.reviewdevelop.dto.UpdateReviewDto;
 import k5s.reviewdevelop.form.ReviewForm;
 import k5s.reviewdevelop.repository.ReviewRepository;
 import k5s.reviewdevelop.service.MemberService;
@@ -15,11 +15,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import javax.validation.constraints.Null;
 import java.util.List;
 
 
@@ -59,7 +57,7 @@ public class ReviewController {
 
         //세션에 회원 데이터가 없으면 home
         if (loginMember == null) {
-            return "redirect:/loginPage";
+            return "redirect:/movies/reviews/loginPage";
         }
         Movie movie = movieService.findOne(movieId);
         //세션이 유지되면 로그인으로 이동
@@ -120,4 +118,6 @@ public class ReviewController {
         reviewService.updateReview(new UpdateReviewDto(form));
         return "redirect:/movies/{movieId}/reviews";
     }
+
+
 }

--- a/chan/src/main/java/k5s/reviewdevelop/controller/SessionHomeController.java
+++ b/chan/src/main/java/k5s/reviewdevelop/controller/SessionHomeController.java
@@ -87,7 +87,7 @@ public class SessionHomeController {
         return "loginHome";
     }
 
-    @GetMapping("/loginPage")
+    @GetMapping("/movies/reviews/loginPage")
     public String loginPage() {
         return "redirect:"+loginURL;
     }

--- a/chan/src/main/java/k5s/reviewdevelop/controller/WebClientController.java
+++ b/chan/src/main/java/k5s/reviewdevelop/controller/WebClientController.java
@@ -1,5 +1,12 @@
 package k5s.reviewdevelop.controller;
 
+import k5s.reviewdevelop.domain.Review;
+import k5s.reviewdevelop.exception.InvalidAuthenticationException;
+import k5s.reviewdevelop.service.AuthService;
+import k5s.reviewdevelop.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -7,7 +14,10 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 @RestController
+@RequiredArgsConstructor
 public class WebClientController {
+
+    private final AuthService authService;
 
     @GetMapping("/test")
     public Mono<String> doTest() {
@@ -21,6 +31,16 @@ public class WebClientController {
     @GetMapping("/webclienttest")
     public String testWebClient() {
         return "hi its Client`";
+    }
+
+    @GetMapping("/movies/webclient")
+    public String myPage(@CookieValue(value = "accessToken", required = false) String accessToken, Model model) {
+        if (accessToken == null) {
+            throw new InvalidAuthenticationException("인증 정보가 존재하지 않습니다.");
+        }
+
+        Long aLong = authService.requestAuthentication(accessToken);
+        return String.valueOf(aLong);
     }
 
 }

--- a/chan/src/main/java/k5s/reviewdevelop/domain/Review.java
+++ b/chan/src/main/java/k5s/reviewdevelop/domain/Review.java
@@ -1,10 +1,9 @@
 package k5s.reviewdevelop.domain;
 
+import k5s.reviewdevelop.dto.UpdateReviewDto;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;

--- a/chan/src/main/java/k5s/reviewdevelop/dto/AuthenticationRequestDto.java
+++ b/chan/src/main/java/k5s/reviewdevelop/dto/AuthenticationRequestDto.java
@@ -1,0 +1,12 @@
+package k5s.reviewdevelop.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AuthenticationRequestDto {
+    String accessToken;
+
+    public AuthenticationRequestDto(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/chan/src/main/java/k5s/reviewdevelop/dto/AuthenticationResponseDto.java
+++ b/chan/src/main/java/k5s/reviewdevelop/dto/AuthenticationResponseDto.java
@@ -1,0 +1,8 @@
+package k5s.reviewdevelop.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AuthenticationResponseDto {
+    Long id;
+}

--- a/chan/src/main/java/k5s/reviewdevelop/dto/UpdateReviewDto.java
+++ b/chan/src/main/java/k5s/reviewdevelop/dto/UpdateReviewDto.java
@@ -1,4 +1,4 @@
-package k5s.reviewdevelop.domain;
+package k5s.reviewdevelop.dto;
 
 import k5s.reviewdevelop.form.ReviewForm;
 import lombok.Getter;

--- a/chan/src/main/java/k5s/reviewdevelop/exception/InvalidAuthenticationException.java
+++ b/chan/src/main/java/k5s/reviewdevelop/exception/InvalidAuthenticationException.java
@@ -1,0 +1,7 @@
+package k5s.reviewdevelop.exception;
+
+public class InvalidAuthenticationException extends RuntimeException{
+    public InvalidAuthenticationException(String message) {
+        super(message);
+    }
+}

--- a/chan/src/main/java/k5s/reviewdevelop/service/AuthService.java
+++ b/chan/src/main/java/k5s/reviewdevelop/service/AuthService.java
@@ -1,0 +1,41 @@
+package k5s.reviewdevelop.service;
+
+import k5s.reviewdevelop.dto.AuthenticationRequestDto;
+import k5s.reviewdevelop.dto.AuthenticationResponseDto;
+import k5s.reviewdevelop.exception.InvalidAuthenticationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthService {
+
+    private final WebClient webClient;
+
+
+    @Transactional
+    public Long requestAuthentication(String accessToken) {
+        AuthenticationRequestDto dto = new AuthenticationRequestDto(accessToken);
+
+        AuthenticationResponseDto result = webClient.post()
+                .uri("/auth/access-token-valid")
+                .body(Mono.just(dto), AuthenticationRequestDto.class)
+                .retrieve()
+                .onStatus(HttpStatus::is4xxClientError, error -> Mono.error(new InvalidAuthenticationException("인증 정보가 존재하지 않습니다.")))
+                .bodyToMono(AuthenticationResponseDto.class)
+                .block();
+
+        if (result.getId() == null) {
+            throw new InvalidAuthenticationException("인증 정보가 존재하지 않습니다.");
+        }
+
+        return result.getId();
+    }
+
+
+}

--- a/chan/src/main/java/k5s/reviewdevelop/service/ReviewService.java
+++ b/chan/src/main/java/k5s/reviewdevelop/service/ReviewService.java
@@ -3,7 +3,7 @@ package k5s.reviewdevelop.service;
 import k5s.reviewdevelop.domain.Member;
 import k5s.reviewdevelop.domain.Movie;
 import k5s.reviewdevelop.domain.Review;
-import k5s.reviewdevelop.domain.UpdateReviewDto;
+import k5s.reviewdevelop.dto.UpdateReviewDto;
 import k5s.reviewdevelop.repository.MemberRepository;
 import k5s.reviewdevelop.repository.MovieRepository;
 import k5s.reviewdevelop.repository.ReviewRepository;

--- a/chan/src/main/resources/application.yml
+++ b/chan/src/main/resources/application.yml
@@ -20,7 +20,7 @@ logging.level:
   org.hibernate.type: trace
 
 server:
-  port : 8081
+  port : 8080
   servlet:
     session:
       timeout: 30m
@@ -28,3 +28,4 @@ server:
 
 msa:
   member-login: http://3.34.45.251/auth/login
+  auth: http://13.209.76.94:8080

--- a/chan/src/test/java/k5s/reviewdevelop/service/ReviewServiceTest.java
+++ b/chan/src/test/java/k5s/reviewdevelop/service/ReviewServiceTest.java
@@ -3,12 +3,11 @@ package k5s.reviewdevelop.service;
 import k5s.reviewdevelop.domain.Member;
 import k5s.reviewdevelop.domain.Movie;
 import k5s.reviewdevelop.domain.Review;
-import k5s.reviewdevelop.domain.UpdateReviewDto;
+import k5s.reviewdevelop.dto.UpdateReviewDto;
 import k5s.reviewdevelop.repository.MovieRepository;
 import k5s.reviewdevelop.repository.ReviewRepository;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.internal.matchers.Null;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -18,9 +17,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.Assert.*;
 

--- a/chan/src/test/resources/application.yml
+++ b/chan/src/test/resources/application.yml
@@ -7,3 +7,4 @@ logging.level:
 
 msa:
   member-login: http://3.34.45.251/auth/login
+  auth: http://13.209.76.94:8080


### PR DESCRIPTION
## 목적
WebClient를 이용하여 로그인을 한 뒤 인증서버에 API 통신을 한다
**API**
- url : `/movies/webclient`
- Post
- Request : `{ accessToken: ~ }`
- Response : `{ id: ~ }`

## 테스트 사항
- [x] Test1
- [x] Test2
- [x] Test3

## Screenshot
<img width="446" alt="image" src="https://user-images.githubusercontent.com/46098949/163938163-ed0f58ef-c983-47f5-871d-be039bc70bf7.png">
로그인한 유저의 id값이 정상적으로 나타난다

## 코드
**WebClientController**
```java
@GetMapping("/movies/webclient")
    public String myPage(@CookieValue(value = "accessToken", required = false) String accessToken, Model model) {
        if (accessToken == null) {
            throw new InvalidAuthenticationException("인증 정보가 존재하지 않습니다.");
        }

        Long aLong = authService.requestAuthentication(accessToken);
        return String.valueOf(aLong);
    }
```

**AuthService**
```java
@Transactional
    public Long requestAuthentication(String accessToken) {
        AuthenticationRequestDto dto = new AuthenticationRequestDto(accessToken);

        AuthenticationResponseDto result = webClient.post()
                .uri("/auth/access-token-valid")
                .body(Mono.just(dto), AuthenticationRequestDto.class)
                .retrieve()
                .onStatus(HttpStatus::is4xxClientError, error -> Mono.error(new InvalidAuthenticationException("인증 정보가 존재하지 않습니다.")))
                .bodyToMono(AuthenticationResponseDto.class)
                .block();

        if (result.getId() == null) {
            throw new InvalidAuthenticationException("인증 정보가 존재하지 않습니다.");
        }

        return result.getId();
    }
```
