### PR TITLE
Fix API for movieServer

### DIFF
--- a/src/main/java/k5s/reviewdevelop/api/MovieAPI.java
+++ b/src/main/java/k5s/reviewdevelop/api/MovieAPI.java
@@ -37,14 +37,13 @@ public class MovieAPI {
 
         MovieRequestDto dto = new MovieRequestDto(movieId);
 
-        MovieResponseDto result = webClientService.setMovieWebClient().post()
-                .uri("/movies")
-                .body(Mono.just(dto), MovieRequestDto.class)
+        MovieResponseDto result = webClientService.setMovieWebClient().get()
+                .uri("/movie/{movieId}", movieId)
                 .retrieve()
                 .onStatus(HttpStatus::is4xxClientError, error -> Mono.error(new NoMovieException("영화오류")))
                 .bodyToMono(MovieResponseDto.class)
                 .timeout(Duration.ofSeconds(5))
-                .onErrorMap(TimeoutException.class, ex -> new NoMovieException("연결시간초과"))
+                .onErrorMap(ExceptionControl::ConnectionError, ex -> new NoMovieException("연결시간초과"))
                 .block();
 
         if (result.getMovieName() == null) {


### PR DESCRIPTION
## 목적
영화서버에게 `movieId`를 보내면 영화서버는 `movieName`을 응답해준다
이 과정에서 `post`방식으로 request를 하였는데 `get`방식으로 request로 변경하였다

## 상세사항
기존코드
![image](https://user-images.githubusercontent.com/46098949/175539768-22f0c2e3-15ef-4935-8312-7f5e493cf585.png)
request시 **HTTP Body**에 찾길 원하는 Data를 넣었음

수정 후
![image](https://user-images.githubusercontent.com/46098949/175540062-edb29f6b-c17a-4c2f-892c-7b12a0ea295c.png)
request시 HTTP Body에 Data를 넣지않고 PathParameter를 사용하여 Data를 삽입


## Screenshot
![image](https://user-images.githubusercontent.com/46098949/175541203-4b61a8f8-e569-40d2-863f-fbac7f1f738a.png)


cf. [movie Server 수정내역](https://github.com/K5S-TEAM/docker-movieServer/commit/73d87e86384aa6b1201f422cb9e2d79208f75641)
```java
@GetMapping("/movie/{id}")
    public ResponseEntity getMovieNames(@PathVariable Long id) {
        List<HotMovie> result = movieService.findOne(id);

        if (result.isEmpty()) {
            return ResponseEntity.status(HttpStatus.NOT_FOUND)
                    .body(null);
        } else {
            return ResponseEntity.status(HttpStatus.OK)
                    .body(new MovieNameResponseDto(result.get(0).getTitle()));
        }
    }
```